### PR TITLE
Make availability_zone configurable for openstack

### DIFF
--- a/templates/openstack.yml.erb
+++ b/templates/openstack.yml.erb
@@ -15,6 +15,9 @@ compilation:
     <% if properties.key_name %>
     key_name: <%= properties.key_name %>
     <% end %>
+    <% if properties.availability_zone %>
+    availability_zone: <%= properties.availability_zone %>
+    <% end %>
 
 update:
   canaries: <%= properties.canaries || 1 %>
@@ -69,6 +72,9 @@ resource_pools:
       instance_type: <%= properties.instance_type || 'm1.small' %>
       <% if properties.key_name %>
       key_name: <%= properties.key_name %>
+      <% end %>
+      <% if properties.availability_zone %>
+      availability_zone: <%= properties.availability_zone %>
       <% end %>
     <% if properties.password %>
     env:


### PR DESCRIPTION
This change modifies the template used for bat deployments
on openstack to make it possible to configure (optionally)
the availability_zone of the compilation and job VMs.