### PR TITLE
Fix how to determine a release is a dev release in BATs. 

### DIFF
--- a/lib/bat/release.rb
+++ b/lib/bat/release.rb
@@ -66,7 +66,7 @@ module Bat
     private
 
     def dev?
-      version =~ /-dev$/
+      version =~ /\+dev$/
     end
   end
 end

--- a/spec/bat/release_spec.rb
+++ b/spec/bat/release_spec.rb
@@ -29,14 +29,14 @@ describe Bat::Release do
         bat_dev_releases_dir = File.join(bat_path, 'dev_releases')
         FileUtils.mkdir_p(bat_dev_releases_dir)
 
-        deployment_file = File.join(bat_dev_releases_dir, 'bat-1.1-dev.yml')
+        deployment_file = File.join(bat_dev_releases_dir, 'bat-1.1+dev.yml')
         File.open(deployment_file, 'w') { |f| f.write("CONTENT: #{deployment_file}") }
       end
 
       it 'creates a Release named "bat" with versions found in the path specified' do
         release = Bat::Release.from_path(bat_path)
         expect(release.name).to eq('bat')
-        expect(release.sorted_versions).to eq(%w(0 1 1.1-dev 12))
+        expect(release.sorted_versions).to eq(%w(0 1 1.1+dev 12))
         expect(release.path).to eq(bat_path)
       end
     end


### PR DESCRIPTION
BATs was always choosing final release because the way to distinguish DEV release is wrong. This would also prevent the RackHD CPI BATs from reaching out to S3. 

[#105875466](https://www.pivotaltracker.com/story/show/105875466)

Signed-off-by: Megan Murawski <megan.hyland@emc.com>