### PR TITLE
Use bosh_ssh instead of ssh

### DIFF
--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -25,10 +25,6 @@ module Bat
       }
     end
 
-    def manual_networking?
-      @env.bat_networking == 'manual'
-    end
-
     def aws?
       @env.bat_infrastructure == 'aws'
     end
@@ -56,8 +52,8 @@ module Bat
       info['features']['dns']['extras']['domain_name'] if dns?
     end
 
-    def persistent_disk(host, user, options = {})
-      get_disks(host, user, options).each do |disk|
+    def persistent_disk(job, index)
+      get_disks(job, index).each do |disk|
         values = disk.last
         if values[:mountpoint] == '/var/vcap/store'
           return values[:blocks]
@@ -88,11 +84,29 @@ module Bat
       output
     end
 
-    def ssh_sudo(host, user, command, options)
-      if options[:password].nil?
-        raise 'Need to set sudo :password'
+    def bosh_ssh(job, index, command, options = {})
+      private_key = ssh_options[:private_key]
+
+      # Try our best to clean out old host fingerprints for director and vms
+      if File.exist?(File.expand_path('~/.ssh/known_hosts'))
+        Bosh::Exec.sh("ssh-keygen -R '#{@env.director}'")
+        Bosh::Exec.sh("ssh-keygen -R '#{static_ip}'")
       end
-      ssh(host, user, "echo #{options[:password]} | sudo -p '' -S #{command}", options)
+
+      if private_key
+        bosh_ssh_options = {
+          gateway_host: @env.director,
+          gateway_user: 'vcap',
+          gateway_identity_file: private_key,
+        }.map { |k, v| "--#{k} '#{v}'" }.join(' ')
+
+        # Note gateway_host + ip: ...fingerprint does not match for "micro.ci2.cf-app.com,54.208.15.101" (Net::SSH::HostKeyMismatch)
+        if File.exist?(File.expand_path('~/.ssh/known_hosts'))
+          Bosh::Exec.sh("ssh-keygen -R '#{@env.director},#{static_ip}'").output
+        end
+      end
+
+      bosh_safe("ssh #{job} #{index} '#{command}' #{bosh_ssh_options}")
     end
 
     def tarfile
@@ -157,11 +171,11 @@ module Bat
       output
     end
 
-    def get_disks(host, user, options)
+    def get_disks(job, index)
       disks = {}
       df_cmd = 'df -x tmpfs -x devtmpfs -x debugfs -l | tail -n +2'
 
-      df_output = ssh(host, user, df_cmd, options)
+      df_output = bosh_ssh(job, index, df_cmd).output
       df_output.split("\n").each do |line|
         fields = line.split(/\s+/)
         disks[fields[0]] = {

--- a/lib/bat/deployment_helper.rb
+++ b/lib/bat/deployment_helper.rb
@@ -129,10 +129,6 @@ module Bat
       static_ips.first
     end
 
-    def includes_vip?
-      !!(@spec['properties']['vip'])
-    end
-
     def vip
       @spec['properties']['vip']
     end
@@ -191,10 +187,6 @@ module Bat
 
     def use_flavor_with_no_ephemeral_disk
       @spec['properties']['instance_type'] = @spec['properties']['flavor_with_no_ephemeral_disk']
-    end
-
-    def dynamic_networking?
-      @spec['properties']['networks'].any? { |n| n['type'] == 'dynamic' }
     end
 
     def network_type

--- a/lib/bat/stemcell.rb
+++ b/lib/bat/stemcell.rb
@@ -34,33 +34,12 @@ module Bat
       path
     end
 
-    def supports_network_reconfiguration?
-      !(name =~ /vcloud/ && name =~ /centos/) && name !~ /warden/
-    end
-
     def sudo_command
       if name =~ /centos/
         "echo #{ENV['BAT_VCAP_PASSWORD']} | sudo -S -p '' -i"
       else
         "echo #{ENV['BAT_VCAP_PASSWORD']} | sudo -S -p '' -s"
       end
-    end
-
-    def supports_root_partition?
-      !!(name =~ /openstack/ && name !~ /centos/)
-    end
-
-    def supports_changing_static_ip?(network_type)
-      # Does not support for openstack dynamic
-      supports_network_reconfiguration? && !(name =~ /openstack/ && network_type == 'dynamic')
-    end
-
-    def supports_multiple_manual_networks?
-      (name =~ /openstack/ && name =~ /go_agent/) || (name =~ /vsphere/ && name =~ /go_agent/)
-    end
-
-    def supports_raw_ephemeral_storage?
-      name =~ /aws/
     end
 
     def ==(other)

--- a/spec/bat/stemcell_spec.rb
+++ b/spec/bat/stemcell_spec.rb
@@ -68,48 +68,6 @@ describe Bat::Stemcell do
     end
   end
 
-  describe '#supports_network_reconfiguration?' do
-    {
-      # Go agent
-      'bosh-custom-xen-ubuntu-trusty-go_agent' => true,
-      'bosh-custom-xen-centos-go_agent' => true,
-      'bosh-aws-xen-hvm-ubuntu-trusty-go_agent' => true,
-      'bosh-aws-xen-centos-7-go_agent' => true,
-      'bosh-vsphere-esxi-ubuntu-trusty-go_agent' => true,
-      'bosh-vsphere-esxi-centos-go_agent' => true,
-      'bosh-vcloud-esxi-ubuntu-trusty-go_agent' => true,
-      'bosh-openstack-kvm-centos-7-go_agent' => true,
-      'bosh-openstack-kvm-ubuntu-trusty-go_agent' => true,
-
-      # Centos currently does not include open-vm-tools
-      'bosh-vcloud-esxi-centos-go_agent' => false,
-
-      # Warden CPI does not support network reconfig
-      'bosh-warden-boshlite-ubuntu-trusty-go_agent' => false,
-      'bosh-warden-boshlite-centos-go_agent' => false,
-
-    }.each do |stemcell_name, expected|
-      it "returns #{expected} for #{stemcell_name}" do
-        stemcell = Bat::Stemcell.new(stemcell_name, nil)
-        expect(stemcell.supports_network_reconfiguration?).to be(expected)
-      end
-    end
-  end
-
-  describe '#supports_root_partition?' do
-    {
-      'bosh-openstack-kvm-centos-go_agent' => false,
-      'bosh-openstack-kvm-ubuntu-trusty-go_agent' => true,
-      'bosh-vsphere-esxi-ubuntu-trusty-go_agent' => false,
-      'bosh-vcloud-esxi-ubuntu-trusty-go_agent' => false,
-    }.each do |stemcell_name, expected|
-      it "returns #{expected} for #{stemcell_name}" do
-        stemcell = Bat::Stemcell.new(stemcell_name, nil)
-        expect(stemcell.supports_root_partition?).to be(expected)
-      end
-    end
-  end
-
   describe '#to_s' do
     it 'returns "<name>-<version>"' do
       expect(stemcell.to_s).to eq('STEMCELL_NAME-STEMCELL_NAME')

--- a/spec/system/env_spec.rb
+++ b/spec/system/env_spec.rb
@@ -1,6 +1,7 @@
 require 'system/spec_helper'
 
-describe 'initialization', :skip_task_check do
+
+describe 'initialization', skip_task_check: true, core: true do
   describe 'environment requirements' do
     it 'should have a readable stemcell' do
       expect(File.exist?(@requirements.stemcell.to_path)).to be(true)

--- a/spec/system/raw_ephemeral_disk_spec.rb
+++ b/spec/system/raw_ephemeral_disk_spec.rb
@@ -1,6 +1,6 @@
 require 'system/spec_helper'
 
-describe 'raw_instance_storage' do
+describe 'raw_instance_storage', raw_ephemeral_disk: true do
   before(:all) do
     @requirements.requirement(@requirements.release)
     @requirements.requirement(@requirements.stemcell)
@@ -12,8 +12,6 @@ describe 'raw_instance_storage' do
   end
 
   before do
-    skip 'raw_instance_storage cloud property not supported on this IaaS' unless @requirements.stemcell.supports_raw_ephemeral_storage?
-
     reload_deployment_spec
     # using password 'foobar'
     use_password('$6$tHAu4zCTso$pAQok0MTHP4newel7KMhTzMI4tQrAWwJ.X./fFAKjbWkCb5sAaavygXAspIGWn8qVD8FeT.Z/XN4dvqKzLHhl0')
@@ -29,11 +27,7 @@ describe 'raw_instance_storage' do
 
   it 'should attach all available instance disks and label them', ssh: true do
     # assumes aws.yml.erb specifies instance_type: m3.medium, which has 1 local disk
-    expect(labeled_partitions(public_ip)).to eq(["raw-ephemeral-0"])
-  end
-
-  def labeled_partitions(ip)
-    output = ssh(ip, 'vcap', 'ls /dev/disk/by-partlabel', @our_ssh_options)
-    output.lines.map { |line| line.chomp }
+    output = bosh_ssh('batlight', 0, 'ls /dev/disk/by-partlabel').output
+    expect(output).to include('raw-ephemeral-0')
   end
 end

--- a/spec/system/with_release_stemcell_deployment_spec.rb
+++ b/spec/system/with_release_stemcell_deployment_spec.rb
@@ -1,6 +1,6 @@
 require 'system/spec_helper'
 
-describe 'with release, stemcell and deployment' do
+describe 'with release, stemcell and deployment', core: true do
   before(:all) do
     @requirements.requirement(@requirements.stemcell)
     @requirements.requirement(@requirements.release)
@@ -20,7 +20,8 @@ describe 'with release, stemcell and deployment' do
   describe 'agent' do
     it 'should survive agent dying', ssh: true do
       Dir.mktmpdir do |tmpdir|
-        ssh(public_ip, 'vcap', "echo #{@env.vcap_password} | sudo -S pkill -9 agent", ssh_options)
+        ssh_command="echo #{@env.vcap_password} | sudo -S pkill -9 agent"
+        expect(bosh_ssh('batlight', 0, ssh_command)).to succeed
         wait_for_vm_state('batlight/0', 'running')
         expect(bosh_safe("logs batlight 0 --agent --dir #{tmpdir}")).to succeed
       end
@@ -29,28 +30,7 @@ describe 'with release, stemcell and deployment' do
 
   describe 'ssh' do
     it 'can bosh ssh into a vm' do
-      private_key = ssh_options[:private_key]
-
-      # Try our best to clean out old host fingerprints for director and vms
-      if File.exist?(File.expand_path('~/.ssh/known_hosts'))
-        Bosh::Exec.sh("ssh-keygen -R '#{@env.director}'")
-        Bosh::Exec.sh("ssh-keygen -R '#{static_ip}'")
-      end
-
-      if private_key
-        bosh_ssh_options = {
-          gateway_host: @env.director,
-          gateway_user: 'vcap',
-          gateway_identity_file: private_key,
-        }.map { |k, v| "--#{k} '#{v}'" }.join(' ')
-
-        # Note gateway_host + ip: ...fingerprint does not match for "micro.ci2.cf-app.com,54.208.15.101" (Net::SSH::HostKeyMismatch)
-        if File.exist?(File.expand_path('~/.ssh/known_hosts'))
-          Bosh::Exec.sh("ssh-keygen -R '#{@env.director},#{static_ip}'")
-        end
-      end
-
-      expect(bosh_safe("ssh batlight 0 'uname -a' #{bosh_ssh_options}")).to succeed_with /Linux/
+      expect(bosh_ssh('batlight', 0, "uname -a").output).to match /Linux/
     end
   end
 

--- a/spec/system/with_release_stemcell_failed_deployment_spec.rb
+++ b/spec/system/with_release_stemcell_failed_deployment_spec.rb
@@ -1,6 +1,6 @@
 require 'system/spec_helper'
 
-describe 'with release, stemcell and failed deployment' do
+describe 'with release, stemcell and failed deployment', core: true do
   let(:deployment_manifest_bad) do
     use_failing_job
     with_deployment

--- a/spec/system/with_release_stemcell_spec.rb
+++ b/spec/system/with_release_stemcell_spec.rb
@@ -7,14 +7,9 @@ describe 'with release and stemcell and subsequent deployments' do
     load_deployment_spec
   end
 
-  context 'with no ephemeral disk' do
+  context 'with no ephemeral disk', root_partition: true do
     before do
-      skip 'only openstack is configurable without ephemeral disk' unless @requirements.stemcell.supports_root_partition?
-
       reload_deployment_spec
-      # using password 'foobar'
-      use_password('$6$tHAu4zCTso$pAQok0MTHP4newel7KMhTzMI4tQrAWwJ.X./fFAKjbWkCb5sAaavygXAspIGWn8qVD8FeT.Z/XN4dvqKzLHhl0')
-      @our_ssh_options = ssh_options.merge(password: 'foobar')
       use_static_ip
       use_vip
       use_job('batlight')
@@ -30,8 +25,8 @@ describe 'with release and stemcell and subsequent deployments' do
       @requirements.cleanup(deployment)
     end
 
-    it 'creates ephemeral and swap partitions on the root device if no ephemeral disk', ssh: true do
-      setting_value = agent_config(public_ip).
+    it 'creates ephemeral and swap partitions on the root device if no ephemeral disk', ssh: true, core: true do
+      setting_value = agent_config().
         fetch('Platform', {}).
         fetch('Linux', {}).
         fetch('CreatePartitionIfNoEphemeralDisk', false)
@@ -39,19 +34,20 @@ describe 'with release and stemcell and subsequent deployments' do
       skip 'root disk ephemeral partition requires a stemcell with CreatePartitionIfNoEphemeralDisk enabled' unless setting_value
 
       # expect ephemeral mount point to be a mounted partition on the root disk
-      expect(mounts(public_ip)).to include(hash_including('path' => '/var/vcap/data'))
+      expect(mounts()).to include(hash_including('path' => '/var/vcap/data'))
 
       # expect swap to be a mounted partition on the root disk
-      expect(swaps(public_ip)).to include(hash_including('type' => 'partition'))
+      expect(swaps()).to include(hash_including('type' => 'partition'))
     end
 
-    def agent_config(ip)
-      output = ssh_sudo(ip, 'vcap', 'cat /var/vcap/bosh/agent.json', @our_ssh_options)
-      JSON.parse(output)
+    def agent_config()
+      output = bosh_ssh('batlight', 0, 'sudo cat /var/vcap/bosh/agent.json').output
+      # regex to extract json file content from bosh response
+      JSON.parse(/\{(?:[^{}]|\g<0>)*\}/.match(output)[0])
     end
 
-    def mounts(ip)
-      output = ssh(ip, 'vcap', 'mount', @our_ssh_options)
+    def mounts()
+      output = bosh_ssh('batlight', 0, 'mount').output
       output.lines.map do |line|
         matches = /(?<point>.*) on (?<path>.*) type (?<type>.*) \((?<options>.*)\)/.match(line)
         next if matches.nil?
@@ -59,8 +55,8 @@ describe 'with release and stemcell and subsequent deployments' do
       end.compact
     end
 
-    def swaps(ip)
-      output = ssh(ip, 'vcap', 'swapon -s', @our_ssh_options)
+    def swaps()
+      output = bosh_ssh('batlight', 0, 'PATH=$PATH:/usr/sbin swapon -s').output
       output.lines.to_a[1..-1].map do |line|
         matches = /(?<point>.+)\s+(?<type>.+)\s+(?<size>.+)\s+(?<used>.+)\s+(?<priority>.+)/.match(line)
         next if matches.nil?
@@ -73,12 +69,11 @@ describe 'with release and stemcell and subsequent deployments' do
     end
   end
 
-  context 'with ephemeral and persistent disk' do
+  context 'with persistent disk size changing', persistent_disk: true do
+    SAVE_FILE = '/var/vcap/store/batarang/save'
+
     before(:all) do
       reload_deployment_spec
-      # using password 'foobar'
-      use_password('$6$tHAu4zCTso$pAQok0MTHP4newel7KMhTzMI4tQrAWwJ.X./fFAKjbWkCb5sAaavygXAspIGWn8qVD8FeT.Z/XN4dvqKzLHhl0')
-      @our_ssh_options = ssh_options.merge(password: 'foobar')
       use_static_ip
       use_vip
       @jobs = %w[
@@ -90,17 +85,56 @@ describe 'with release and stemcell and subsequent deployments' do
       use_persistent_disk(2048)
 
       @requirements.requirement(deployment, @spec)
+
+      bosh_ssh('colocated', 0, "sudo sh -c \"echo 'foobar' > #{SAVE_FILE}\"")
+      unless warden?
+        @size = persistent_disk('colocated', 0)
+      end
+      use_persistent_disk(4096)
+      @requirements.requirement(deployment, @spec, force: true)
     end
 
     after(:all) do
       @requirements.cleanup(deployment)
     end
 
-    it 'should set vcap password', ssh: true do
-      expect(ssh_sudo(public_ip, 'vcap', 'whoami', @our_ssh_options)).to eq("root\n")
+    it 'should migrate disk contents', ssh: true do
+      # Warden df don't work so skip the persistent disk size check
+      unless warden?
+        expect(persistent_disk('colocated', 0)).to_not eq(@size)
+      end
+      expect(bosh_ssh('colocated', 0, "cat #{SAVE_FILE}").output).to match /foobar/
+    end
+  end
+
+  describe 'general stemcell configuration' do
+    before(:all) do
+      reload_deployment_spec
+      # using password 'foobar'
+      use_password('$6$tHAu4zCTso$pAQok0MTHP4newel7KMhTzMI4tQrAWwJ.X./fFAKjbWkCb5sAaavygXAspIGWn8qVD8FeT.Z/XN4dvqKzLHhl0')
+      use_static_ip
+      use_vip
+      @jobs = %w[
+        /var/vcap/packages/batlight/bin/batlight
+        /var/vcap/packages/batarang/bin/batarang
+      ]
+      use_job('colocated')
+      use_templates(%w[batarang batlight])
+
+      @requirements.requirement(deployment, @spec)
     end
 
-    it 'should not change the deployment on a noop' do
+    after(:all) do
+      @requirements.cleanup(deployment)
+    end
+
+    # this test case will not test password for vcap correctly after changing to bosh_ssh.
+    # even with ssh, if we set private_key in our ssh_option, we still failing testing password.
+    it 'should set vcap password', ssh: true, core: true do
+      expect(bosh_ssh('colocated', 0, 'sudo whoami').output).to match /root/
+    end
+
+    it 'should not change the deployment on a noop', core: true do
       deployment_result = bosh('deploy')
       events(get_task_id(deployment_result.output)).each do |event|
         if event['stage']
@@ -109,50 +143,25 @@ describe 'with release and stemcell and subsequent deployments' do
       end
     end
 
-    it 'should use job colocation', ssh: true do
+    it 'should use job colocation', ssh: true, core: true do
       @jobs.each do |job|
-        grep_cmd = "ps -ef | grep #{job} | grep -v grep"
-        expect(ssh(public_ip, 'vcap', grep_cmd, @our_ssh_options)).to match /#{job}/
+        ssh_command = "ps -ef | grep #{job} | grep -v grep"
+        expect(bosh_ssh('colocated', 0, ssh_command).output).to match /#{job}/
       end
     end
 
-    it 'should have network access to the vm using the manual static ip' do
-      skip "not applicable for dynamic networking" if dynamic_networking?
-
+    it 'should have network access to the vm using the manual static ip', manual_networking: true do
       vm = wait_for_vm('colocated/0')
       expect(vm).to_not be_nil
       expect(static_ip).to_not be_nil
-      expect(ssh(public_ip, 'vcap', 'hostname', @our_ssh_options)).to match /#{vm[:agent_id]}/
+      expect(bosh_ssh('colocated', 0, 'hostname').output).to match /#{vm[:agent_id]}/
     end
 
-    it 'should have network access to the vm using the vip' do
-      skip "vip network isn't supported" unless includes_vip?
-
+    it 'should have network access to the vm using the vip', vip_networking: true do
       vm = wait_for_vm('colocated/0')
       expect(vm).to_not be_nil
       expect(vip).to_not be_nil
-      expect(ssh(vip, 'vcap', 'hostname', @our_ssh_options)).to match /#{vm[:agent_id]}/
-    end
-
-    context 'changing the persistent disk size' do
-      SAVE_FILE = '/var/vcap/store/batarang/save'
-
-      before(:all) do
-        ssh(public_ip, 'vcap', "echo 'foobar' > #{SAVE_FILE}", @our_ssh_options)
-        unless warden?
-          @size = persistent_disk(public_ip, 'vcap', @our_ssh_options)
-        end
-        use_persistent_disk(4096)
-        @requirements.requirement(deployment, @spec, force: true)
-      end
-
-      it 'should migrate disk contents', ssh: true do
-        # Warden df don't work so skip the persistent disk size check
-        unless warden?
-          expect(persistent_disk(public_ip, 'vcap', @our_ssh_options)).to_not eq(@size)
-        end
-        expect(ssh(public_ip, 'vcap', "cat #{SAVE_FILE}", @our_ssh_options)).to match /foobar/
-      end
+      expect(bosh_ssh('colocated', 0, 'hostname').output).to match /#{vm[:agent_id]}/
     end
   end
 end


### PR DESCRIPTION
- Add bosh_ssh, bosh_ssh_sudo in bosh_helper
- Modify swapon command to include additional path
- Change signature of get_disk, get_persistent due to bosh_ssh change
- Remove ssh_sudo due to new stemcell supporting sudo without password
- Remove some helper functions to make BATs not IS releated
- Tag different tests with tags: core,
                                 persistent_disk,
                                 vip_networking,
                                 dynamic_networking,
                                 manual_networking,
                                 root_partition,
                                 changing_static_ip,
                                 multiple_manual_networks,
                                 network_reconfiguration,
                                 raw_ephemeral_storagei

Signed-off-by: Thinh Nguyen <thinh.nguyen@emc.com>