### PR TITLE
Fix flaky test 'should survive agent dying'

### DIFF
--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -114,14 +114,32 @@ module Bat
       @logger.info("Start waiting for vm #{name}")
       vm = nil
       5.times do
-        vm = get_vms.find { |v| v[:vm] =~ /#{name} \(.*\)/ }
+        vm = get_vm(name)
         break if vm
       end
       @logger.info("Finished waiting for vm #{name} vm=#{vm.inspect}")
       vm
     end
 
+    def wait_for_vm_state(name, state)
+      puts "Start waiting for vm #{name} to have state #{state}"
+      vm_in_state = nil
+      5.times do
+        vm = get_vm(name)
+        if vm && vm[:state] =~ /#{state}/
+          vm_in_state = vm
+          break
+        end
+      end
+      puts "Finished waiting for vm #{name} to have sate=#{state} vm=#{vm_in_state.inspect}"
+      vm_in_state
+    end
+
     private
+
+    def get_vm(name)
+      get_vms.find { |v| v[:vm] =~ /#{name} \(.*\)/ }
+    end
 
     def get_vms
       output = @bosh_runner.bosh('vms --details').output

--- a/spec/system/with_release_stemcell_deployment_spec.rb
+++ b/spec/system/with_release_stemcell_deployment_spec.rb
@@ -21,7 +21,7 @@ describe 'with release, stemcell and deployment' do
     it 'should survive agent dying', ssh: true do
       Dir.mktmpdir do |tmpdir|
         ssh(public_ip, 'vcap', "echo #{@env.vcap_password} | sudo -S pkill -9 agent", ssh_options)
-        wait_for_vm('batlight/0')
+        wait_for_vm_state('batlight/0', 'running')
         expect(bosh_safe("logs batlight 0 --agent --dir #{tmpdir}")).to succeed
       end
     end


### PR DESCRIPTION
- 'should survive agent dying' kills the bosh agent and than
   tries to download agent logs. For this it needs a running agent.
   A new help method has been added 'wait_for_vm_state' which
   is used to wait for the agent to be in running state.

Fixes #16
[#114688001](https://www.pivotaltracker.com/story/show/114688001)