### PR TITLE
Disable rp_filter inside batlight job

### DIFF
--- a/spec/system/assets/bat-release/jobs/batlight/spec
+++ b/spec/system/assets/bat-release/jobs/batlight/spec
@@ -2,6 +2,7 @@
 name: batlight
 
 templates:
+  pre-start.erb: bin/pre-start
   batlight_ctl.erb: bin/batlight_ctl
   drain.erb: bin/drain
   properties.erb: config/properties

--- a/spec/system/assets/bat-release/jobs/batlight/templates/pre-start.erb
+++ b/spec/system/assets/bat-release/jobs/batlight/templates/pre-start.erb
@@ -5,12 +5,8 @@
 # is assigned multiple IP address from the same subnet.
 # This command disables rp filtering.
 
-find /proc/sys/net/ipv4/conf/ -type f -name 'rp_filter' 2>/dev/null | grep -q '.*'
-rp_filters_exists=$?
-
-if [ "${rp_filters_exists}" -eq 0 ]; then
-  echo "Disabling rp_filter..."
-  echo 0 | tee /proc/sys/net/ipv4/conf/*/rp_filter > /dev/null
-fi
+for file in /proc/sys/net/ipv4/conf/*/rp_filter; do
+  [ -f $file ] && echo 0 > $file
+done
 
 exit 0

--- a/spec/system/assets/bat-release/jobs/batlight/templates/pre-start.erb
+++ b/spec/system/assets/bat-release/jobs/batlight/templates/pre-start.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Newer stemcells turn on Reverse Path Filtering as a security precaution.
+# This breaks some multiple-homed director tests in vSphere when a VM
+# is assigned multiple IP address from the same subnet.
+# This command disables rp filtering.
+
+find /proc/sys/net/ipv4/conf/ -type f -name 'rp_filter' 2>/dev/null | grep -q '.*'
+rp_filters_exists=$?
+
+if [ "${rp_filters_exists}" -eq 0 ]; then
+  echo "Disabling rp_filter..."
+  echo 0 | tee /proc/sys/net/ipv4/conf/*/rp_filter > /dev/null
+fi
+
+exit 0


### PR DESCRIPTION
- This allows us to more easily test multi-homed jobs in vSphere
  - For ease of testing, we use a single vSphere network and assign the VM multiple IPs from that one network
  - Recent STIGs changes introduced rp_filtering, which makes breaks the above setup

[#121162417](https://www.pivotaltracker.com/story/show/121162417)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>