### PR TITLE
Fix system service spec

### DIFF
--- a/spec/system/auditd_spec.rb
+++ b/spec/system/auditd_spec.rb
@@ -14,7 +14,7 @@ describe 'auditd, sshd, cron, rsyslogd', system_services_running: true do
 
   it 'should be running' do
     output = bosh_ssh('batlight', 0, 'ps ax -o ucmd').output
-    running_services = output.split('\n').uniq
+    running_services = output.split("\n").uniq
 
     expect(running_services).to include('cron')
     expect(running_services).to include('kauditd')

--- a/spec/system/auditd_spec.rb
+++ b/spec/system/auditd_spec.rb
@@ -16,7 +16,7 @@ describe 'auditd, sshd, cron, rsyslogd', system_services_running: true do
     output = bosh_ssh('batlight', 0, 'ps ax -o ucmd').output
     running_services = output.split("\n").uniq
 
-    expect(running_services).to include('cron')
+    expect(running_services).to include(/^crond?$/)
     expect(running_services).to include('kauditd')
     expect(running_services).to include('rsyslogd')
   end


### PR DESCRIPTION
- Uses double quotes to escape newline
- Expects either `cron` OR `crond` to be running