### PR TITLE
Don't suppress exceptions when calling bosh ssh

### DIFF
--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -106,7 +106,7 @@ module Bat
         end
       end
 
-      bosh_safe("ssh #{job} #{index} '#{command}' #{bosh_ssh_options}")
+      bosh("ssh #{job} #{index} '#{command}' #{bosh_ssh_options}")
     end
 
     def tarfile


### PR DESCRIPTION
When there was an error with ssh during the test, the test didn't stop and
failed later with an error not directly related to the actual error. With
this change the test fails earlier when something goes wrong.

[#131983509](https://www.pivotaltracker.com/story/show/131983509)

Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>