### PR TITLE
Explicitly check that hostname is set to agent ID

### DIFF
--- a/spec/system/with_release_stemcell_spec.rb
+++ b/spec/system/with_release_stemcell_spec.rb
@@ -163,5 +163,11 @@ describe 'with release and stemcell and subsequent deployments' do
       expect(vip).to_not be_nil
       expect(bosh_ssh('colocated', 0, 'hostname').output).to match /#{vm[:agent_id]}/
     end
+
+    it 'should set the hostname to the agent id', core: true do
+      vm = wait_for_vm_state('colocated', '0', 'running')
+      expect(vm).to_not be_nil
+      expect(bosh_ssh('colocated', 0, 'hostname').output).to match /#{vm[:agent_id]}/
+    end
   end
 end


### PR DESCRIPTION
- essentially a duplicate of the networking tests, but the hostname call in those
  tests seemed like it was used out of convenience and could change in the future

[#133124133](https://www.pivotaltracker.com/story/show/133124133)

Signed-off-by: Brian Cunnie bcunnie@pivotal.io
