### PR TITLE
Make instance_type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The BOSH Acceptance Tests are meant to be used to verify the commonly used functionality of BOSH.
 
+**Note**: If you're just getting started with BATs, please refer to and use the [gocli-bats](https://github.com/cloudfoundry/bosh-acceptance-tests/tree/gocli-bats) branch which uses the newer [bosh CLI v2](http://bosh.io/docs/cli-v2.html). This `master` branch is being retained until all existing pipelines have migrated tests away from the Ruby CLI to the new CLI.
+
 It requires a BOSH deployment, either a deployed micro bosh stemcell, or a full bosh-release deployment.
 
 See [running bats](https://github.com/cloudfoundry/bosh/blob/master/docs/running_tests.md#bosh-acceptance-tests-bats) for how to run them.

--- a/lib/bat/requirements.rb
+++ b/lib/bat/requirements.rb
@@ -102,7 +102,7 @@ module Bat
         @logger.info('deployment not already deployed, deploying...')
         what.generate_deployment_manifest(deployment_spec)
         expect(@bosh_runner.bosh_safe("deployment #{what.to_path}")).to succeed
-        expect(@bosh_runner.bosh_safe('deploy --no-redact')).to succeed
+        expect(@bosh_runner.bosh_safe('deploy')).to succeed
       end
     rescue RSpec::Expectations::ExpectationNotMetError
       @spec_state.register_fail

--- a/spec/bat/bosh_runner_spec.rb
+++ b/spec/bat/bosh_runner_spec.rb
@@ -26,6 +26,40 @@ describe Bat::BoshRunner do
       subject.bosh('FAKE_ARGS')
     end
 
+    context 'when appending deploy options' do
+      it 'adds --no-redact to deploy command' do
+        expected_command = %W(
+        fake-bosh-exe
+        --non-interactive
+        -P 1
+        --config fake-path-to-bosh-config
+        --user admin --password admin
+        deploy --no-redact 2>&1
+      ).join(' ')
+
+        expect(logger).to receive(:info).with("Running bosh command --> #{expected_command}")
+        expect(bosh_exec).to receive(:sh).with(expected_command, {}).and_return(bosh_exec_result)
+
+        subject.bosh('deploy')
+      end
+
+      it 'does not add --no-redact to the deployment command' do
+        expected_command = %W(
+        fake-bosh-exe
+        --non-interactive
+        -P 1
+        --config fake-path-to-bosh-config
+        --user admin --password admin
+        deployment 2>&1
+      ).join(' ')
+
+        expect(logger).to receive(:info).with("Running bosh command --> #{expected_command}")
+        expect(bosh_exec).to receive(:sh).with(expected_command, {}).and_return(bosh_exec_result)
+
+        subject.bosh('deployment')
+      end
+    end
+
     it 'returns the result of Bosh::Exec' do
       allow(bosh_exec).to receive(:sh).and_return(bosh_exec_result)
 

--- a/templates/aws.yml.erb
+++ b/templates/aws.yml.erb
@@ -11,7 +11,7 @@ compilation:
   network: default
   reuse_compilation_vms: true
   cloud_properties:
-    instance_type: m3.medium
+    instance_type: <%= properties.instance_type || "m3.medium" %>
     availability_zone: <%= properties.availability_zone %>
     <% if properties.key_name %>
     key_name: <%= properties.key_name %>
@@ -68,7 +68,7 @@ resource_pools:
       name: <%= properties.stemcell.name %>
       version: '<%= properties.stemcell.version %>'
     cloud_properties:
-      instance_type: m3.medium
+      instance_type: <%= properties.instance_type || "m3.medium" %>
       availability_zone: <%= properties.availability_zone %>
       <% if properties.key_name %>
       key_name: <%= properties.key_name %>


### PR DESCRIPTION
instance_type reconfigurable through `properties.instance_type`
defaults: m3.medium
fixes:
```
Your requested instance type (m3.medium) is not supported in your requested Availability Zone (us-east-1a). Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1c, us-east-1d, us-east-1e.```