### PR TITLE
Make instance_type configurable

### DIFF
--- a/templates/aws.yml.erb
+++ b/templates/aws.yml.erb
@@ -10,7 +10,7 @@ compilation:
   network: default
   reuse_compilation_vms: true
   cloud_properties:
-    instance_type: m3.medium
+    instance_type: <%= properties.instance_type || "m3.medium" %>
     availability_zone: <%= properties.availability_zone %>
 
 update:
@@ -63,7 +63,7 @@ resource_pools:
       name: <%= properties.stemcell.name %>
       version: '<%= properties.stemcell.version %>'
     cloud_properties:
-      instance_type: m3.medium
+      instance_type: <%= properties.instance_type || "m3.medium" %>
       availability_zone: <%= properties.availability_zone %>
       <% if properties.raw_instance_storage %>
       raw_instance_storage: <%= properties.raw_instance_storage %>


### PR DESCRIPTION
instance_type reconfigurable through `properties.instance_type`
defaults: m3.medium
fixes:
```
Your requested instance type (m3.medium) is not supported in your requested Availability Zone (us-east-1a). Please retry your request by not specifying an Availability Zone or choosing us-east-1b, us-east-1c, us-east-1d, us-east-1e.```