### PR TITLE
Oracle template for running Gocli bats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export BAT_BOSH_CLI=bosh2
 # DNS host or IP where BOSH-controlled PowerDNS server is running, which is required for the DNS tests. For example, if BAT is being run against a MicroBOSH then this value will be the same as BAT_DIRECTOR
 export BAT_DNS_HOST=
 
-# the name of infrastructure that is used by bosh deployment. Examples: aws, vsphere, openstack, warden.
+# the name of infrastructure that is used by bosh deployment. Examples: aws, vsphere, openstack, warden, oci.
 export BAT_INFRASTRUCTURE=
 
 # the type of networking being used: `dynamic` or `manual`.
@@ -51,7 +51,7 @@ export BOSH_OS_BATS=true
 Provide all necessary variables for the BOSH cli to connect to the director, e.g.:
 
 ```
-export BOSH_ENVIRONMENT=<director ip>
+export BOSH_ENVIRONMENT=<director ip or alias to bosh-env>
 export BOSH_CLIENT=<director username>
 export BOSH_CLIENT_SECRET=<director password>
 export BOSH_CA_CERT=<director ca cert content or path>
@@ -178,6 +178,47 @@ properties:
     gateway: 192.168.79.1
     vlan: Network_Name # vSphere network name
 ```
+
+### Oracle Cloud Infrastructure (OCI)
+#### Manual networking
+
+Example bat.yml pointed to by `BAT_DEPLOYMENT_SPEC` environment variable 
+
+```yaml
+
+---
+cpi: oci 
+properties:
+  stemcell:
+    name: light-oracle-ubuntu-stemcell 
+    version: latest
+  instances: 1
+  instance_shape: 'VM.Standard1.2' # Instance shape
+  availability_domain: WZYX:PHX-AD-3 
+
+  networks:
+  - name: default
+    type: manual
+    static_ip: 10.0.X.30 # Primary (private) IP assigned to the bat-release job vm (primary NIC), must be in the primary static range
+    cloud_properties:
+      vcn: cloudfoundry_vcn 
+      subnet: private_subnet_ad3 
+    cidr: 10.0.X.0/24 # CIDR bock of the subnet
+    reserved: ['10.0.X.2 - 10.0.X.9'] # 
+    static: ['10.0.X.10 - 10.0.X.30']
+    gateway: 10.0.X.1
+  - name: second # Secondary network for testing jobs with multiple manual networks
+    type: manual
+    static_ip: 10.0.Y.30 # Must be in the static range defined below
+    cloud_properties:
+      vcn: cloudfoundry_vcn 
+      subnet: private_subnet_ad3_for_bats 
+    cidr: 10.0.Y.0/24
+    reserved: ['10.0.Y.2 - 10.0.Y.9']
+    static: ['10.0.Y.10 - 10.0.Y.30']
+    gateway: 10.0.Y.1
+```
+
 
 ## Setup IaaS
 

--- a/templates/oci.yml.erb
+++ b/templates/oci.yml.erb
@@ -1,0 +1,95 @@
+---
+name: <%= properties.name || "bat" %>
+
+releases:
+  - name: bat
+    version: <%= properties.release || "latest" %>
+
+compilation:
+  workers: 2
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_shape: <%= properties.instance_shape || 'VM.Standard1.2' %>
+    availability_domain: <%= properties.availability_domain %>
+
+update:
+  canaries: <%= properties.canaries || 1 %>
+  canary_watch_time: 3000-90000
+  update_watch_time: 3000-90000
+  max_in_flight: <%= properties.max_in_flight || 1 %>
+
+networks:
+<% properties.networks.each do |network| %>
+- name: <%= network.name %>
+  type: <%= network.type %>
+  <% if network.type == 'manual' %>
+  subnets:
+  - range: <%= network.cidr %>
+    reserved:
+      <% network.reserved.each do |range| %>
+      - <%= range %>
+      <% end %>
+    static:
+      <% network.static.each do |range| %>
+      - <%= range %>
+      <% end %>
+    gateway: <%= network.gateway %>
+    dns: <%= p('dns').inspect %>
+    cloud_properties:
+      vcn: <%= network.cloud_properties.vcn %>
+      subnet_name: <%= network.cloud_properties.subnet %>
+  <% else %>
+  dns: <%= p('dns').inspect %>
+  cloud_properties:
+      vcn: <%= network.cloud_properties.vcn %>
+      subnet_name: <%= network.cloud_properties.subnet %>
+  <% end %>
+<% end %>
+
+resource_pools:
+  - name: common
+    network: default
+    stemcell:
+      name: <%= properties.stemcell.name %>
+      version: '<%= properties.stemcell.version %>'
+    cloud_properties:
+      instance_shape: <%= properties.instance_shape || 'VM.Standard1.2' %>
+      availability_domain: <%= properties.availability_domain %>
+
+jobs:
+  - name: <%= properties.job || "batlight" %>
+    templates: <% (properties.templates || ["batlight"]).each do |template| %>
+    - name: <%= template %>
+    <% end %>
+    instances: <%= properties.instances %>
+    resource_pool: common
+    <% if properties.persistent_disk %>
+    persistent_disk: <%= properties.persistent_disk %>
+    <% end %>
+    networks:
+    <% properties.job_networks.each_with_index do |network, i| %>
+      - name: <%= network.name %>
+      <% if i == 0 %>
+        default: [dns, gateway]
+      <% end %>
+      <% if network.type == 'manual' %>
+        static_ips:
+        <% if properties.use_static_ip %>
+        - <%= network.static_ip %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+properties:
+  batlight:
+    <% if properties.batlight.fail %>
+    fail: <%= properties.batlight.fail %>
+    <% end %>
+    <% if properties.batlight.missing %>
+    missing: <%= properties.batlight.missing %>
+    <% end %>
+    <% if properties.batlight.drain_type %>
+    drain_type: <%= properties.batlight.drain_type %>
+    <% end %>
+


### PR DESCRIPTION
1) Adds template for running BATs on Oracle Cloud Infrastructure using Oracle CPI. The tests are currently run manually. Adding the template will allow BATs to be integrated with the bosh-cpi-certification.

2) Disable the DNS tests as suggested by @cppforlife.   