### PR TITLE
Option to support availability zone in Azure template

### DIFF
--- a/templates/azure.yml.erb
+++ b/templates/azure.yml.erb
@@ -15,6 +15,9 @@ compilation:
     <% if properties.key_name %>
     key_name: <%= properties.key_name %>
     <% end %>
+    <% if properties.availability_zone %>
+    availability_zone: <%= properties.availability_zone %>
+    <% end %>
 
 update:
   canaries: <%= properties.canaries || 1 %>
@@ -80,6 +83,9 @@ resource_pools:
       instance_type: <%= properties.resource_pool_instance_type || "Standard_D3_v2" %>
       <% if properties.key_name %>
       key_name: <%= properties.key_name %>
+      <% end %>
+      <% if properties.availability_zone %>
+      availability_zone: <%= properties.availability_zone %>
       <% end %>
     <% if properties.password %>
     env:


### PR DESCRIPTION
Azure Availability Zone is in preview. Adding an option to support zone in bosh bats. We will run bats in Azure CPI pipeline initially.