### PR TITLE
Fix Tests

### DIFF
--- a/spec/system/service_configuration_spec.rb
+++ b/spec/system/service_configuration_spec.rb
@@ -10,6 +10,8 @@ describe 'service configuration', :type => 'os'  do
     load_deployment_spec
     use_static_ip
     use_vip
+    # pw == 'foobar'
+    use_password('$6$tHAu4zCTso$pAQok0MTHP4newel7KMhTzMI4tQrAWwJ.X./fFAKjbWkCb5sAaavygXAspIGWn8qVD8FeT.Z/XN4dvqKzLHhl0')
     @requirements.requirement(deployment, @spec) # 2.5 min on local vsphere
   end
 
@@ -18,16 +20,16 @@ describe 'service configuration', :type => 'os'  do
   end
 
   let(:sudo) do
-    @requirements.stemcell.sudo_command
+    "echo foobar | sudo -S "
   end
 
   def instance_reboot(ip)
     # turn off vm resurrection
-    bosh('vm resurrection off')
+    bosh('update-resurrection off')
 
     # shutdown instance
     begin
-      ssh(ip, 'jumpbox', "#{sudo} reboot", ssh_options)
+      ssh(ip, 'vcap', "#{sudo} reboot", ssh_options.merge({ :password => 'foobar'}))
     rescue IOError
       @logger.debug('Rebooting instance closed the ssh connection')
     end
@@ -38,7 +40,7 @@ describe 'service configuration', :type => 'os'  do
     loop do
       sleep 10
       begin
-        result = ssh(ip, 'jumpbox', "echo 'UP'", ssh_options)
+        result = ssh(ip, 'vcap', "echo 'UP'", ssh_options.merge({ :password => 'foobar'}))
       rescue Exception => e
         @logger.info("Failed to run ssh command. Retrying. Message: #{e.message}")
       end
@@ -48,13 +50,13 @@ describe 'service configuration', :type => 'os'  do
     expect(result).to eq("UP\n")
 
     # turn on vm resurrection
-    bosh('vm resurrection on')
+    bosh('update-resurrection on')
   end
 
   def dump_log(ip, log_path)
     @logger.info("Dumping log file '#{log_path}'")
     @logger.info("================================================================================")
-    ssh(ip, 'jumpbox', "([ -f '#{log_path}' ] && cat #{log_path})", ssh_options)
+    ssh(ip, 'vcap', "([ -f '#{log_path}' ] && cat #{log_path})", ssh_options.merge({ :password => 'foobar'}))
   end
 
   def process_running_on_instance(ip, process_name)
@@ -63,7 +65,7 @@ describe 'service configuration', :type => 'os'  do
     pid = ''
     loop do
       sleep 1
-      pid = ssh(ip, 'jumpbox', "pgrep #{process_name}", ssh_options)
+      pid = ssh(ip, 'vcap', "pgrep #{process_name}", ssh_options.merge({ :password => 'foobar'}))
       break unless (tries += 1) < 30 && (pid =~ /^\d+\n$/).nil?
     end
 
@@ -167,7 +169,7 @@ describe 'service configuration', :type => 'os'  do
             echo "FAILURE: expected /etc/service/monit to be younger than uptime, got a difference of ${diff} seconds"
           fi
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       context 'when monit dies' do
@@ -181,7 +183,7 @@ describe 'service configuration', :type => 'os'  do
             if [[ "${new_pid}" = "${old_pid}" || -z "${new_pid}" ]]; then echo 'FAILURE'; fi
             echo "SUCCESS"
           EOF
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
         end
       end
 
@@ -196,7 +198,7 @@ describe 'service configuration', :type => 'os'  do
             if [[ "${new_pid}" = "${old_pid}" || -z "${new_pid}" ]]; then echo 'FAILURE'; fi
             echo "SUCCESS"
           EOF
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
         end
       end
     end
@@ -231,7 +233,7 @@ describe 'service configuration', :type => 'os'  do
           fi
           echo "SUCCESS"
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       context 'when monit dies' do
@@ -246,7 +248,7 @@ describe 'service configuration', :type => 'os'  do
             _=$(killAndAwaitProcess monit)
             echo "SUCCESS"
           EOF
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
         end
       end
 
@@ -262,7 +264,7 @@ describe 'service configuration', :type => 'os'  do
             _=$(killAndAwaitProcess bosh-agent)
             echo "SUCCESS"
           EOF
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
         end
       end
     end
@@ -282,7 +284,7 @@ describe 'service configuration', :type => 'os'  do
       it 'mounts tmpfs to /var/vcap/data/sys/run' do
         # verify mount point for sys/run
         cmd = "if [ x`mount | grep -c /var/vcap/data/sys/run` = x1 ] ; then echo 'SUCCESS' ; fi"
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       it 'creates a symlink from /etc/sv/monit to /etc/service/monit' do
@@ -300,7 +302,7 @@ describe 'service configuration', :type => 'os'  do
           fi
           echo 'SUCCESS'
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       it 'does not keep pre-existing pid files in sys/run after instance reboot' do
@@ -328,7 +330,7 @@ describe 'service configuration', :type => 'os'  do
           touch /var/vcap/data/sys/run/foo.pid
           echo 'SUCCESS'
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
 
         # reboot instance
         instance_reboot(public_ip)
@@ -359,7 +361,7 @@ describe 'service configuration', :type => 'os'  do
           fi
           echo 'SUCCESS'
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
     end
 
@@ -378,7 +380,7 @@ describe 'service configuration', :type => 'os'  do
             echo "FAILURE: foo not existing anymore"
           fi
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       it 'does not remove existing pid files' do
@@ -397,7 +399,7 @@ describe 'service configuration', :type => 'os'  do
             echo 'FAILURE: batlight.pid changed'
           fi
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       it 'does not recreates a symlink from /etc/sv/monit to /etc/service/monit' do
@@ -413,7 +415,7 @@ describe 'service configuration', :type => 'os'  do
             echo 'FAILURE: /etc/service/monit modified'
           fi
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
 
       it 'does not restart monit' do
@@ -432,7 +434,7 @@ describe 'service configuration', :type => 'os'  do
             echo 'FAILURE: monit restarted'
           fi
         EOF
-        expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+        expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
       end
     end
   end
@@ -451,7 +453,7 @@ describe 'service configuration', :type => 'os'  do
 
           # kill batlight
           cmd = "#{sudo} pkill batlight && echo 'SUCCESS'"
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
 
           # wait for batlight to come up again
           batlight_running_on_instance(public_ip)
@@ -464,14 +466,14 @@ describe 'service configuration', :type => 'os'  do
         it 'restarts it' do
           # kill monit
           cmd = "#{sudo} pkill monit && echo 'SUCCESS'"
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
 
           # wait for monit to come up again
           monit_running_on_instance(public_ip)
 
           # kill batlight
           cmd = "#{sudo} pkill batlight && echo 'SUCCESS'"
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
 
           # wait for batlight to come up again
           batlight_running_on_instance(public_ip)
@@ -480,14 +482,14 @@ describe 'service configuration', :type => 'os'  do
 
       context 'when monit is running' do
         it 'can not be reached from the host' do
-          cmd = "#{sudo} netstat -ntpl | grep monit | awk '{print $4}' | xargs curl -m1"
-          expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to match("Connection timed out")
+          cmd = "#{sudo} -- netstat -ntpl | grep monit | awk '{print $4}' | xargs curl -m1"
+          expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("Connection timed out")
         end
 
         context 'when using the monit cli' do
           it 'can reach the api and show a summary' do
             cmd = "#{sudo} monit summary && echo 'SUCCESS'"
-            expect(ssh(public_ip, 'jumpbox', cmd, ssh_options)).to eq("SUCCESS\n")
+            expect(ssh(public_ip, 'vcap', cmd, ssh_options.merge({ :password => 'foobar'}))).to include("SUCCESS\n")
           end
         end
       end


### PR DESCRIPTION
there were a few problems with the tests.

1. the ssh command used the jumpbox user
   that user cannot be present as the deployment does not contain os_conf release to configure it
2. it used an ssh key to connect
   can't be there as no SSH keys are configured for users on a bosh deployed vm
3. the resurrection command was broken
   it used a bad syntax
4. the .eq checks for SUCCESS had to be changed
   the output contains additional data and the test couldn't pass
5. the sudo command requires reading the password from stdin,
   it appears that the vcap user is not able to do passwordless sudo at this stage