### PR TITLE
fix require of `minitar`

### DIFF
--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -3,13 +3,12 @@ require 'json'
 require 'net/ssh'
 require 'net/ssh/gateway'
 require 'zlib'
-require 'archive/tar/minitar'
+require 'minitar'
 require 'tempfile'
 require 'common/exec'
 
 module Bat
   module BoshHelper
-    include Archive::Tar
 
     def bosh(*args, &blk)
       @bosh_runner.bosh(*args, &blk)


### PR DESCRIPTION
The 1.0.0 release of `minitar` removed the `archive/lib` directory