### PR TITLE
increase wait time for agent to be up to 5 min

### DIFF
--- a/spec/system/service_configuration_spec.rb
+++ b/spec/system/service_configuration_spec.rb
@@ -45,7 +45,7 @@ describe 'service configuration', os: true  do
       rescue Bosh::Exec::Error
         @logger.info("Failed to run ssh command. Retrying.")
       end
-      break if (Time.now.to_i - start) > 180 || result.include?("UP")
+      break if (Time.now.to_i - start) > 300 || result.include?("UP")
     end
 
     expect(result).to include("UP")


### PR DESCRIPTION
timeout used to be 3 mins and in some environments on vsphere it look longer which made bats fail

the fips stemcell specifically was failing because of this