### PR TITLE
Add tests for nic groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ properties:
     subnet: subnet-xxxxxxxx # VPC subnet
     nic_group: 2
     security_groups: 'bat' # VPC security groups
-  - name: default2
+  - name: default3
     type: manual
     static_ip: 10.10.2.30
     cidr: 10.10.2.0/24

--- a/README.md
+++ b/README.md
@@ -82,6 +82,67 @@ properties:
   key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
 ```
 
+#### manual networking with multiple networks and nic groups
+
+```yaml
+---
+cpi: aws
+properties:
+  stemcell:
+    name: bosh-aws-xen-ubuntu-trusty-go_agent
+    version: latest
+  instances: 1
+  ssh_gateway:
+    host: "jumpbox_host" # optional host used to provide tunnel when the tests need to ssh to VMs
+    username: "jumpbox_username" # optional username used to provide tunnel when the tests need to ssh to VMs
+  ssh_key_pair:
+    public_key: "public_key_string" # used when deploying VMs to allow direct ssh access
+    private_key: "private_key_string" # used to ssh into bosh deployed VMs and the gateway host
+  vip: 54.54.54.54 # elastic ip for bat deployed VM
+  second_static_ip: 10.10.0.31 # Secondary (private) IP to use for reconfiguring networks, must be in the primary network & different from static_ip
+  networks:
+  - name: default
+    type: manual
+    static_ip: 10.10.0.30
+    cidr: 10.10.0.0/24
+    reserved: ['10.10.0.2 - 10.10.0.9']
+    static: ['10.10.0.10 - 10.10.0.31']
+    gateway: 10.10.0.1
+    subnet: subnet-xxxxxxxx # VPC subnet
+    nic_group: 1
+    security_groups: 'bat' # VPC security groups
+  - name: second_ipv6
+    type: manual
+    cidr: 2001:db8:abcd:1234::/56
+    reserved: ['2001:db8:abcd:1234::2 - 2001:db8:abcd:1234::f']
+    static_ip: 2001:db8:abcd:1234::10
+    gateway: 2001:db8:abcd:1234::1
+    subnet: subnet-xxxxxxxx
+    security_groups: 'bat'
+    nic_group: 1
+  - name: default2
+    type: manual
+    static_ip: 10.10.1.30
+    cidr: 10.10.1.0/24
+    reserved: ['10.10.1.2 - 10.10.1.9']
+    static: ['10.10.1.10 - 10.10.1.31']
+    gateway: 10.10.1.1
+    subnet: subnet-xxxxxxxx # VPC subnet
+    nic_group: 2
+    security_groups: 'bat' # VPC security groups
+  - name: default2
+    type: manual
+    static_ip: 10.10.2.30
+    cidr: 10.10.2.0/24
+    reserved: ['10.10.2.2 - 10.10.2.9']
+    static: ['10.10.2.10 - 10.10.2.31']
+    gateway: 10.10.2.1
+    subnet: subnet-xxxxxxxx # VPC subnet
+    nic_group: 2
+    security_groups: 'bat' # VPC security groups
+  key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
+```
+
 ### OpenStack
 
 #### dynamic networking

--- a/README.md
+++ b/README.md
@@ -105,41 +105,41 @@ properties:
     type: manual
     static_ip: 10.10.0.30
     cidr: 10.10.0.0/24
-    reserved: ['10.10.0.2 - 10.10.0.9']
-    static: ['10.10.0.10 - 10.10.0.31']
+    reserved: ["10.10.0.2 - 10.10.0.9"]
+    static: ["10.10.0.10 - 10.10.0.31"]
     gateway: 10.10.0.1
     subnet: subnet-xxxxxxxx # VPC subnet
     nic_group: 1
-    security_groups: 'bat' # VPC security groups
-  - name: second_ipv6
+    security_groups: "bat" # VPC security groups
+  - name: second
     type: manual
     cidr: 2001:db8:abcd:1234::/56
-    reserved: ['2001:db8:abcd:1234::2 - 2001:db8:abcd:1234::f']
+    reserved: ["2001:db8:abcd:1234::2 - 2001:db8:abcd:1234::f"]
     static_ip: 2001:db8:abcd:1234::10
     gateway: 2001:db8:abcd:1234::1
     subnet: subnet-xxxxxxxx
-    security_groups: 'bat'
+    security_groups: "bat"
     nic_group: 1
-  - name: default2
+  - name: third
     type: manual
     static_ip: 10.10.1.30
     cidr: 10.10.1.0/24
-    reserved: ['10.10.1.2 - 10.10.1.9']
-    static: ['10.10.1.10 - 10.10.1.31']
+    reserved: ["10.10.1.2 - 10.10.1.9"]
+    static: ["10.10.1.10 - 10.10.1.31"]
     gateway: 10.10.1.1
     subnet: subnet-xxxxxxxx # VPC subnet
     nic_group: 2
-    security_groups: 'bat' # VPC security groups
-  - name: default3
+    security_groups: "bat" # VPC security groups
+  - name: fourth
     type: manual
-    static_ip: 10.10.2.30
-    cidr: 10.10.2.0/24
-    reserved: ['10.10.2.2 - 10.10.2.9']
-    static: ['10.10.2.10 - 10.10.2.31']
-    gateway: 10.10.2.1
+    static_ip: 2001:db8:cafe:5678::10
+    cidr: 2001:db8:cafe:5678::/56
+    reserved: ["2001:db8:cafe:5678::2 - 2001:db8:cafe:5678::f"]
+    static: ["2001:db8:cafe:5678::10 - 2001:db8:cafe:5678::1f"]
+    gateway: 2001:db8:cafe:5678::1
     subnet: subnet-xxxxxxxx # VPC subnet
     nic_group: 2
-    security_groups: 'bat' # VPC security groups
+    security_groups: "bat" # VPC security groups
   key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The 'dns' property MUST NOT be specified in the BAT deployment spec properties. 
 
 ### AWS
 
-#### manual networking
+#### manual networking (IPv6, IPv6 prefix, nic_groups, multiple manual networks)
 
 ```yaml
 ---
@@ -80,98 +80,18 @@ properties:
     gateway: 10.10.0.1
     subnet: subnet-xxxxxxxx # VPC subnet
     security_groups: 'bat' # VPC security groups
-  key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
-```
-
-#### manual networking with multiple networks and nic groups
-```yaml
----
-cpi: aws
-properties:
-  stemcell:
-    name: bosh-aws-xen-ubuntu-trusty-go_agent
-    version: latest
-  instances: 1
-  ssh_gateway:
-    host: "jumpbox_host" # optional host used to provide tunnel when the tests need to ssh to VMs
-    username: "jumpbox_username" # optional username used to provide tunnel when the tests need to ssh to VMs
-  ssh_key_pair:
-    public_key: "public_key_string" # used when deploying VMs to allow direct ssh access
-    private_key: "private_key_string" # used to ssh into bosh deployed VMs and the gateway host
-  vip: 54.54.54.54 # elastic ip for bat deployed VM
-  second_static_ip: 10.10.0.31 # Secondary (private) IP to use for reconfiguring networks, must be in the primary network & different from static_ip
-  networks:
-  - name: default
-    type: manual
-    static_ip: 10.10.0.30
-    cidr: 10.10.0.0/24
-    reserved: ["10.10.0.2 - 10.10.0.9"]
-    static: ["10.10.0.10 - 10.10.0.31"]
-    gateway: 10.10.0.1
-    subnet: subnet-xxxxxxxx # VPC subnet
     nic_group: 1
-    security_groups: "bat" # VPC security groups
   - name: second
     type: manual
-    cidr: 2001:db8:abcd:1234::/56
-    reserved: ["2001:db8:abcd:1234::2 - 2001:db8:abcd:1234::f"]
-    static_ip: 2001:db8:abcd:1234::10
-    gateway: 2001:db8:abcd:1234::1
-    subnet: subnet-xxxxxxxx
-    security_groups: "bat"
-    nic_group: 1
-  - name: third
-    type: manual
-    static_ip: 10.10.1.30
-    cidr: 10.10.1.0/24
-    reserved: ["10.10.1.2 - 10.10.1.9"]
-    static: ["10.10.1.10 - 10.10.1.31"]
-    gateway: 10.10.1.1
-    subnet: subnet-xxxxxxxx # VPC subnet
-    nic_group: 2
-    security_groups: "bat" # VPC security groups
-  - name: fourth
-    type: manual
-    static_ip: 2001:db8:cafe:5678::10
-    cidr: 2001:db8:cafe:5678::/56
-    reserved: ["2001:db8:cafe:5678::2 - 2001:db8:cafe:5678::f"]
-    static: ["2001:db8:cafe:5678::10 - 2001:db8:cafe:5678::1f"]
-    gateway: 2001:db8:cafe:5678::1
-    subnet: subnet-xxxxxxxx
-    nic_group: 2
-    security_groups: "bat"
-   key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
-```
-
-#### manual networking with multiple networks and prefix allocation
-
-```yaml
----
-cpi: aws
-properties:
-  stemcell:
-    name: bosh-aws-xen-ubuntu-trusty-go_agent
-    version: latest
-  instances: 1
-  ssh_gateway:
-    host: "jumpbox_host" # optional host used to provide tunnel when the tests need to ssh to VMs
-    username: "jumpbox_username" # optional username used to provide tunnel when the tests need to ssh to VMs
-  ssh_key_pair:
-    public_key: "public_key_string" # used when deploying VMs to allow direct ssh access
-    private_key: "private_key_string" # used to ssh into bosh deployed VMs and the gateway host
-  vip: 54.54.54.54 # elastic ip for bat deployed VM
-  second_static_ip: 10.10.0.31 # Secondary (private) IP to use for reconfiguring networks, must be in the primary network & different from static_ip
-  networks:
-  - name: default
-    type: manual
-    static_ip: 10.10.0.30
-    cidr: 10.10.0.0/24
-    reserved: ['10.10.0.2 - 10.10.0.9']
-    static: ['10.10.0.10 - 10.10.0.31']
+    static_ip: 10.10.0.32
+    cidr: 10.10.0.32/24
+    reserved: ['10.10.0.33 - 10.10.0.39']
+    static: ['10.10.0.40 - 10.10.0.5f']
     gateway: 10.10.0.1
-    subnet: subnet-xxxxxxxx # VPC subnet
-    security_groups: 'bat' # VPC security groups
-  - name: second
+    subnet: subnet-xxxxxxxx
+    security_groups: 'bat'
+    nic_group: 2
+  - name: ipv6
     type: manual
     static_ip: 2001:db8:abcd:1234::30
     cidr: 2001:db8:abcd:1234::/56
@@ -180,7 +100,8 @@ properties:
     gateway: 2001:db8:abcd:1234::1
     subnet: subnet-xxxxxxxx
     security_groups: 'bat'
-  - name: third
+    nic_group: 1
+  - name: prefix
     type: manual
     cidr: 2001:db8:abcd:1234::/56
     reserved: ['2001:db8:abcd:1234::2 - 2001:db8:abcd:1234::f']
@@ -188,6 +109,7 @@ properties:
     prefix: 80
     subnet: subnet-xxxxxxxx
     security_groups: 'bat'
+    nic_group: 1
   key_name: bosh # (optional) SSH keypair name, overrides the director's default_key_name setting
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ properties:
     nic_group: 1
   - name: second
     type: manual
-    static_ip: 10.10.0.32
-    cidr: 10.10.0.32/24
+    static_ip: 10.10.0.50
+    cidr: 10.10.0.0/24
     reserved: ['10.10.0.33 - 10.10.0.39']
-    static: ['10.10.0.40 - 10.10.0.5f']
+    static: ['10.10.0.40 - 10.10.0.51']
     gateway: 10.10.0.1
     subnet: subnet-xxxxxxxx
     security_groups: 'bat'

--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -101,8 +101,8 @@ module Bat
       bosh_ssh_options << '--results' if options.delete(:result)
       bosh_ssh_options << " --column=#{column}" if column
       bosh("ssh #{job}/#{index} -c '#{command}' #{bosh_ssh_options}", options)
-      # TODO: we should consider using -r to get propper output
-      # this means fixing al the other tests that rely on the current output
+      # TODO: we should consider using --result (-r) by default to get a proper output
+      # this means fixing all the other tests that rely on the current output
     end
 
     def service_command(job, index, deployment)
@@ -246,12 +246,6 @@ module Bat
       return false if instance.nil?
 
       true
-    end
-
-    # TODO: Temporary solution until -r is implemented
-    # in the bosh_ssh function
-    def extract_ssh_stdout_between_dashes(output)
-      output[/----(.*?)----/m, 1]&.strip
     end
   end
 end

--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -247,5 +247,11 @@ module Bat
 
       true
     end
+
+    # TODO: Temporary solution until -r is implemented
+    # in the bosh_ssh function
+    def extract_ssh_stdout_between_dashes(output)
+      output[/----(.*?)----/m, 1]&.strip
+    end
   end
 end

--- a/lib/bat/bosh_helper.rb
+++ b/lib/bat/bosh_helper.rb
@@ -273,11 +273,5 @@ module Bat
 
       true
     end
-
-    # TODO: Temporary solution until -r is implemented
-    # in the bosh_ssh function
-    def extract_ssh_stdout_between_dashes(output)
-      output[/----(.*?)----/m, 1]&.strip
-    end
   end
 end

--- a/lib/bat/deployment_helper.rb
+++ b/lib/bat/deployment_helper.rb
@@ -180,6 +180,15 @@ module Bat
       @spec['properties'].fetch('network', {}).fetch('type', nil)
     end
 
+    def nic_groups
+       @spec['properties']['job_networks'].inject([]) do |memo, network|
+        if network['nic_group']
+          memo << network['nic_group']
+        end
+        memo
+      end
+    end
+
     def get_most_recent_task_id
       output = @bosh_runner.bosh("tasks --recent=1").output
       JSON.parse(output)["Tables"].first["Rows"].first["id"]

--- a/lib/bat/deployment_helper.rb
+++ b/lib/bat/deployment_helper.rb
@@ -21,6 +21,9 @@ module Bat
       @spec['properties']['batlight']['missing'] = 'nope'
       # dup the job_network so test-local mutations don't affect other tests
       @spec['properties']['job_networks'] = [@spec['properties']['networks'].first.dup]
+      # Set default values for network filtering
+      @spec['properties']['network_prefixes'] = false
+      @spec['properties']['ipv6'] = false
     end
 
     # if with_deployment() is called without a block, it is up to the caller to
@@ -113,12 +116,9 @@ module Bat
     end
 
     def static_ips
-      @spec['properties']['job_networks'].inject([]) do |memo, network|
-        if network['type'] == 'manual'
-          memo << network['static_ip']
-        end
-        memo
-      end
+      filter_networks(@spec['properties']['job_networks'])
+        .select { |network| network['type'] == 'manual' }
+        .map { |network| network['static_ip'] }
     end
 
     def use_second_static_ip
@@ -130,23 +130,19 @@ module Bat
       @spec['properties']['second_static_ip']
     end
 
-    def network_prefixes
-      @spec['properties']['job_networks'].inject([]) do |memo, network|
-        if network['prefix']
-          memo << network['prefix']
-        end
-        memo
-      end
+    def use_ipv6_network_prefixes
+      @spec['properties']['network_prefixes'] = true
+    end
+
+    def use_ipv6
+      @spec['properties']['ipv6'] = true
     end
 
     def use_multiple_manual_networks
-      @spec['properties']['job_networks'] = []
-      @spec['properties']['networks'].each do |network|
-        if network['type'] == 'manual'
-          # dup the job_networks so test-local mutations don't affect other tests
-          @spec['properties']['job_networks'] << network.dup
-        end
-      end
+      @spec['properties']['job_networks'] =
+        filter_networks(@spec['properties']['networks'] || [])
+          .select { |network| network['type'] == 'manual' }
+          .map { |network| network.dup }
     end
 
     def use_raw_instance_storage
@@ -189,10 +185,8 @@ module Bat
       @spec['properties'].fetch('network', {}).fetch('type', nil)
     end
 
-    def nic_groups
-      @spec['properties']['job_networks']
-        .select { |network| network['nic_group'] }
-        .map { |network| network['nic_group'] }
+    def use_nic_groups
+      @spec['properties']['use_nic_groups'] = true
     end
 
     def get_most_recent_task_id
@@ -230,6 +224,26 @@ module Bat
     end
 
     private
+
+    def filter_networks(networks)
+      filtered = networks || []
+      
+      if @spec['properties']['network_prefixes'] == false
+        filtered = filtered.reject { |n| n['prefix'] }
+      end
+      
+      if @spec['properties']['ipv6'] == false
+        filtered = filtered.reject { |n| ipv6_network?(n) }
+      end
+      
+      filtered
+    end
+
+    def ipv6_network?(network)
+      return true if network['static_ip'] && network['static_ip'].include?(':')
+
+      false
+    end
 
     def spec
       @spec ||= {}

--- a/lib/bat/deployment_helper.rb
+++ b/lib/bat/deployment_helper.rb
@@ -240,7 +240,7 @@ module Bat
     end
 
     def ipv6_network?(network)
-      return true if network['static_ip'] && network['static_ip'].include?(':')
+      return true if network['cidr'] && network['cidr'].include?(':')
 
       false
     end

--- a/lib/bat/deployment_helper.rb
+++ b/lib/bat/deployment_helper.rb
@@ -181,12 +181,9 @@ module Bat
     end
 
     def nic_groups
-       @spec['properties']['job_networks'].inject([]) do |memo, network|
-        if network['nic_group']
-          memo << network['nic_group']
-        end
-        memo
-      end
+      @spec['properties']['job_networks']
+        .select { |network| network['nic_group'] }
+        .map { |network| network['nic_group'] }
     end
 
     def get_most_recent_task_id

--- a/spec/system/ipv6_network_configuration_spec.rb
+++ b/spec/system/ipv6_network_configuration_spec.rb
@@ -6,49 +6,52 @@ describe 'IPv6 network configuration', multiple_manual_networks: true, ipv6: tru
   before(:all) do
     @requirements.requirement(@requirements.stemcell)
     @requirements.requirement(@requirements.release)
-    load_deployment_spec
   end
 
   context 'when using manual networking and ipv6', ipv6_manual_networking: true do
     before(:all) do
+      load_deployment_spec
+      use_ipv6
+      use_nic_groups
       use_static_ip
       use_multiple_manual_networks
       @deployment = with_deployment
       expect(bosh("-d #{@deployment.name} deploy #{@deployment.to_path}")).to succeed
-
-      @requirements.requirement(@deployment, @spec)
     end
 
     after(:all) do
-      @requirements.cleanup(@deployment) if @deployment
+      @requirements.cleanup(@deployment)
     end
 
     it 'supports manual network dual stack', dual_stack: true, ssh: true do
-      output = bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig', deployment: @deployment.name).output
-      expect(output).to include(static_ips[0])
-      expect(output).to include(static_ips[1])
+      instance_ips = get_instance_ips
+      expect(instance_ips.values.first.length).to be > 1
+
+      interfaces = bosh_ssh('batlight', 0, 'ip -o addr', deployment: @deployment.name, result: true,
+                                                         column: 'stdout').output
+
+      @spec['properties']['job_networks'].select { |n| n['static_ip'] }.each do |network|
+        expect(interfaces).to include(network['static_ip'])
+      end
     end
   end
 
   context 'when allocating IPv6 prefix', ipv6_prefix_allocation: true do
     before(:all) do
       load_deployment_spec
-      use_multiple_manual_networks
+      use_ipv6_network_prefixes
+      use_ipv6
+      use_nic_groups
       no_static_ip
+      use_multiple_manual_networks
       use_instance_count(2)
 
-      if network_prefixes.empty?
-        skip 'Skipping IPv6 prefix allocation tests because a prefix is not defined under a network'
-      end
-
-      @prefix_deployment = with_deployment
-      expect(bosh("-d #{@prefix_deployment.name} deploy #{@prefix_deployment.to_path}")).to succeed
-
-      @requirements.requirement(@prefix_deployment, @spec)
+      @deployment = with_deployment
+      expect(bosh("-d #{@deployment.name} deploy #{@deployment.to_path}")).to succeed
     end
 
     after(:all) do
-      @requirements.cleanup(@prefix_deployment) if @prefix_deployment
+      @requirements.cleanup(@deployment)
     end
 
     it 'verifies the IPv6 prefix in spec.json', ssh: true do
@@ -59,56 +62,77 @@ describe 'IPv6 network configuration', multiple_manual_networks: true, ipv6: tru
       instances_prefix_ips.each_with_index do |(instance, ip_with_prefix), index|
         ip, prefix = ip_with_prefix.split('/')
         instance_name, instance_id = instance.split('/')
-        cli_cmd = 'output_data=$(sudo cat /var/vcap/bosh/spec.json); echo "----$output_data----"'
-        spec_output = bosh_ssh(instance_name, instance_id, cli_cmd, deployment: @prefix_deployment.name).output
-        json_str = extract_ssh_stdout_between_dashes(spec_output)
-        spec = JSON.parse(json_str)
+        cli_cmd = 'sudo cat /var/vcap/bosh/spec.json'
+        spec_output = bosh_ssh(instance_name, instance_id, cli_cmd, deployment: @deployment.name, result: true,
+                                                                    column: 'stdout').output
+        spec = JSON.parse(spec_output)
 
         found = spec['networks'].values.any? do |net|
           IPAddr.new(net['ip']) == IPAddr.new(ip) && net['prefix'].to_s == prefix.to_s
         end
 
-        expect(found).to eq(true), "IPv6 address #{ip_with_prefix} not found in spec.json networks for instance #{index}"
+        expect(found).to eq(true),
+                         "IPv6 address #{ip_with_prefix} not found in spec.json networks for instance #{index}"
       end
     end
 
     it 'creates a deployment with 2 instances and verifies inter-instance IPv6 prefix connectivity', ssh: true do
       instances_prefix_ips = get_ipv6_prefix_addresses
-
+      expect(instances_prefix_ips).not_to be_nil, 'Expected instances to have IPv6 prefix addresses but received nil'
       expect(instances_prefix_ips.keys.length).to be >= 2
+
       instances_prefix_ips.each do |instance, ip_with_prefix|
         expect(ip_with_prefix).not_to be_nil, "Instance #{instance} does not have an IPv6 address with prefix"
       end
 
-      # Transform the prefix IPs to an actual IPv6 addresses
       instances_usable_ips = {}
       instances_prefix_ips.each do |instance, ip_with_prefix|
-        prefix_ip = ip_with_prefix.split('/')[0].chomp('::')
-        usable_ip = "#{prefix_ip}::20"
-        instances_usable_ips[instance] = usable_ip
+        prefix_ip, prefix_len = ip_with_prefix.split('/')
+        usable_ip = "#{prefix_ip.chomp('::')}::20"
+        usable_ip_with_prefix = "#{usable_ip}/#{prefix_len}"
+        instances_usable_ips[instance] = { usable_ip: usable_ip, usable_ip_with_prefix: usable_ip_with_prefix }
       end
 
-      # Configure each instance with its IPv6 address
-      instances_usable_ips.each do |instance, usable_ip|
+      instances_usable_ips.each do |instance, data|
+        usable_ip = data[:usable_ip]
+        usable_ip_with_prefix = data[:usable_ip_with_prefix]
+
         instance_name, instance_id = instance.split('/')
+        begin
+          # Grab the interface associated by the IaaS with the prefix from the kernel routes
+          probe_cmd = "ip -j -6 route get #{usable_ip}"
+          probe_output = bosh_ssh(instance_name, instance_id, probe_cmd, deployment: @deployment.name,
+                                                                         result: true, column: 'stdout').output
+          # ip -j returns JSON like: [{"dst":"...","from":"::","dev":"eth1",...}]
+          parsed = JSON.parse(probe_output)
+          interface = parsed[0]['dev'] if parsed && parsed[0] && parsed[0]['dev']
+          if interface.nil? || interface.to_s.empty?
+            raise "Failed to determine interface from 'ip -j -6 route get' output on instance #{instance}: #{probe_output.inspect}"
+          end
+        rescue JSON::ParserError
+          raise "Failed to parse JSON output from 'ip route' command on instance #{instance}"
+        end
+
         config_cmd = <<~SCRIPT
-          echo "[Address]" | sudo tee -a /etc/systemd/network/10_eth0.network
-          echo "Address=#{usable_ip}" | sudo tee -a /etc/systemd/network/10_eth0.network
+          echo "[Address]" | sudo tee -a /etc/systemd/network/10_#{interface}.network
+          echo "Address=#{usable_ip_with_prefix}" | sudo tee -a /etc/systemd/network/10_#{interface}.network
           sudo /var/vcap/bosh/bin/restart_networking
         SCRIPT
-        bosh_ssh(instance_name, instance_id, config_cmd, deployment: @prefix_deployment.name)
+        bosh_ssh(instance_name, instance_id, config_cmd, deployment: @deployment.name)
       end
 
       # Test inter-instance connectivity - each instance pings the other
-      instances_usable_ips.each do |source_instance, source_ip|
+      instances_usable_ips.each_key do |source_instance|
         source_name, source_id = source_instance.split('/')
 
-        instances_usable_ips.each do |target_instance, target_ip|
-          next if source_instance == target_instance  # Skip pinging self
+        instances_usable_ips.each do |target_instance, data|
+          next if source_instance == target_instance # Skip pinging self
 
-          ping_result = bosh_ssh(source_name, source_id, "ping6 -c 5 #{target_ip}", deployment: @prefix_deployment.name).output
+          ping_result = bosh_ssh(source_name, source_id, "ping6 -c 5 #{data[:usable_ip]}",
+                                 deployment: @deployment.name, result: true, column: 'stdout').output
           success = ping_result.match(/0% packet loss/) || ping_result.match(/\d+ packets transmitted, \d+ received/)
-          expect(success).to be_truthy, "Ping6 from instance #{source_instance} to #{target_instance} (#{target_ip}) failed: #{ping_result}"
+          expect(success).to be_truthy,
+                             "Ping6 from instance #{source_instance} to #{target_instance} (#{data[:usable_ip_with_prefix]}) failed: #{ping_result}"
         end
       end
     end

--- a/spec/system/ipv6_network_configuration_spec.rb
+++ b/spec/system/ipv6_network_configuration_spec.rb
@@ -88,6 +88,7 @@ describe 'IPv6 network configuration', multiple_manual_networks: true, ipv6: tru
       instances_usable_ips = {}
       instances_prefix_ips.each do |instance, ip_with_prefix|
         prefix_ip, prefix_len = ip_with_prefix.split('/')
+        # Use a random address within the allocated prefix for testing connectivity
         usable_ip = "#{prefix_ip.chomp('::')}::20"
         usable_ip_with_prefix = "#{usable_ip}/#{prefix_len}"
         instances_usable_ips[instance] = { usable_ip: usable_ip, usable_ip_with_prefix: usable_ip_with_prefix }

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -52,9 +52,9 @@ describe 'network configuration' do
       deployment = with_deployment
       expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
 
-      cli_cmd = 'output_data=$(ip -j addr); echo "----$output_data----"'
-      output = bosh_ssh('batlight', 0, cli_cmd, deployment: deployment.name).output
-      raw_interfaces_json = JSON.parse(extract_ssh_stdout_between_dashes(output))
+      cli_cmd = 'ip -j addr'
+      output = bosh_ssh('batlight', 0, cli_cmd, deployment: deployment.name, result: true, column: 'stdout').output
+      raw_interfaces_json = JSON.parse(output)
 
       ip_to_interface_map = {}
       raw_interfaces_json.reject { |iface| iface['ifname'] == 'lo' }.each do |iface|

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -63,6 +63,7 @@ describe 'network configuration' do
         end
       end
 
+      # {<nic_group>=>#<Set: {"NICX"}>, <nic_group>=>#<Set: {"NICX"}>}
       nic_group_to_interface_set = Hash.new { |h, k| h[k] = Set.new }
       networks_with_nic_groups.each do |network|
         static_ip = network['static_ip']

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -18,21 +18,73 @@ describe 'network configuration' do
   end
 
   context 'when using manual networking', manual_networking: true do
-    it 'changes static IP address', changing_static_ip: true, ssh: true do
-      use_second_static_ip
-      deployment = with_deployment
-      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
-
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig', deployment: deployment.name).output).to include(second_static_ip)
-    end
-
     it 'deploys multiple manual networks', multiple_manual_networks: true, ssh: true do
       use_multiple_manual_networks
       deployment = with_deployment
       expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
 
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig', deployment: deployment.name).output).to include(static_ips[0])
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig', deployment: deployment.name).output).to include(static_ips[1])
+      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
+                      deployment: deployment.name).output).to include(static_ips[0])
+      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
+                      deployment: deployment.name).output).to include(static_ips[1])
+    end
+
+    it 'changes static IP address', changing_static_ip: true, ssh: true do
+      use_second_static_ip
+      deployment = with_deployment
+      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
+
+      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
+                      deployment: deployment.name).output).to include(second_static_ip)
+    end
+  end
+
+  context 'when using nic_groups', nic_groups: true do
+    before(:all) do
+      skip 'nic_groups are not supported on AWS CPI' if aws?
+    end
+    it 'assigns networks with the same nic_group to the same interface', ssh: true do
+      use_multiple_manual_networks
+
+      job_networks = @spec['properties']['job_networks']
+      networks_with_nic_groups = job_networks.select { |n| n['static_ip'] && n['nic_group'] }
+      expect(networks_with_nic_groups.size).to be > 0,
+                                               'No networks with nic_group found to test. At least one network should have a nic_group property.'
+
+      deployment = with_deployment
+      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
+
+      cli_cmd = 'output_data=$(ip -j addr); echo "----$output_data----"'
+      output = bosh_ssh('batlight', 0, cli_cmd, deployment: deployment.name).output
+      raw_interfaces_json = JSON.parse(extract_ssh_stdout_between_dashes(output))
+
+      interfaces = raw_interfaces_json.reject { |iface| iface['ifname'] == 'lo' }
+                                 .map do |iface|
+        { 'ifname' => iface['ifname'], 'ips' => iface['addr_info'].map do |addr|
+          addr['local']
+        end }
+      end
+
+      ip_to_interface = {}
+      interfaces.each do |iface|
+        iface['ips'].each { |ip| ip_to_interface[ip] = iface['ifname'] }
+      end
+
+      nic_group_to_interfaces = Hash.new { |h, k| h[k] = Set.new }
+      networks_with_nic_groups.each do |network|
+        static_ip = network['static_ip']
+        nic_group = network['nic_group']
+        interface = ip_to_interface[static_ip]
+
+        expect(interface).not_to be_nil,
+                                 "Static IP #{static_ip} from network '#{network['name']}' not found on any interface"
+        nic_group_to_interfaces[nic_group] << interface
+      end
+
+      nic_group_to_interfaces.each do |nic_group, interface_set|
+        expect(interface_set.size).to eq(1),
+                                      "Networks with nic_group #{nic_group} should be on the same interface, but found on: #{interface_set.to_a.join(', ')}"
+      end
     end
   end
 end

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -64,7 +64,7 @@ describe 'network configuration' do
 
       output = bosh_ssh('batlight', 0, 'ip -j addr', deployment: @deployment.name, result: true,
                                                      column: 'stdout').output
-      raw_interfaces_json = JSON.parse(output)
+      raw_interfaces_json = parse_json_safely(output)
 
       ip_to_interface_map = {}
       raw_interfaces_json.reject { |iface| iface['ifname'] == 'lo' }.each do |iface|

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -36,10 +36,9 @@ describe 'network configuration' do
 
       interfaces = bosh_ssh('batlight', 0, 'ip -o addr', deployment: deployment.name, result: true,
                                                          column: 'stdout').output
-      instance_ips = get_instance_ips
-      expect(instance_ips.values.first.length).to be > 1
-      @spec['properties']['job_networks'].select { |n| n['static_ip'] }.each do |network|
-        expect(interfaces).to include(network['static_ip'])
+      expect(get_instance_ips.values.first.length).to be > 1
+      static_ips.each do |network|
+        expect(interfaces).to include(network)
       end
     end
   end

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -40,7 +40,7 @@ describe 'network configuration' do
     end
   end
 
-  context 'when using nic_groups', nic_groups: true do
+  context 'when using nic_groups', nic_groups: true, multiple_manual_networks: true do
     before(:all) do
       use_multiple_manual_networks
       skip "Skipping nic_groups tests because a nic_group is not defined" if nic_groups.empty?

--- a/spec/system/network_configuration_spec.rb
+++ b/spec/system/network_configuration_spec.rb
@@ -5,29 +5,19 @@ describe 'network configuration' do
   before(:all) do
     @requirements.requirement(@requirements.stemcell)
     @requirements.requirement(@requirements.release)
-  end
-
-  before(:all) do
     load_deployment_spec
-    use_static_ip
-    use_vip
-    @requirements.requirement(deployment, @spec) # 2.5 min on local vsphere
-  end
-
-  after(:all) do
-    @requirements.cleanup(deployment)
   end
 
   context 'when using manual networking', manual_networking: true do
-    it 'deploys multiple manual networks', multiple_manual_networks: true, ssh: true do
-      use_multiple_manual_networks
-      deployment = with_deployment
-      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
+    before(:all) do
+      use_static_ip
+      use_vip
+      @deployment = with_deployment
+      expect(bosh("-d #{@deployment.name} deploy #{@deployment.to_path}")).to succeed
+    end
 
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
-                      deployment: deployment.name).output).to include(static_ips[0])
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
-                      deployment: deployment.name).output).to include(static_ips[1])
+    after(:all) do
+      @requirements.cleanup(@deployment)
     end
 
     it 'changes static IP address', changing_static_ip: true, ssh: true do
@@ -35,25 +25,46 @@ describe 'network configuration' do
       deployment = with_deployment
       expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
 
-      expect(bosh_ssh('batlight', 0, 'PATH=/sbin:/usr/sbin:$PATH; ifconfig',
-                      deployment: deployment.name).output).to include(second_static_ip)
+      expect(bosh_ssh('batlight', 0, 'ip -o addr', deployment: deployment.name, result: true,
+                                                   column: 'stdout').output).to include(second_static_ip)
+    end
+
+    it 'deploys multiple manual networks', multiple_manual_networks: true, ssh: true do
+      use_multiple_manual_networks
+      deployment = with_deployment
+      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
+
+      interfaces = bosh_ssh('batlight', 0, 'ip -o addr', deployment: deployment.name, result: true,
+                                                         column: 'stdout').output
+      instance_ips = get_instance_ips
+      expect(instance_ips.values.first.length).to be > 1
+      @spec['properties']['job_networks'].select { |n| n['static_ip'] }.each do |network|
+        expect(interfaces).to include(network['static_ip'])
+      end
     end
   end
 
   context 'when using nic_groups', nic_groups: true, multiple_manual_networks: true do
     before(:all) do
+      load_deployment_spec
+      use_nic_groups
+      use_static_ip
       use_multiple_manual_networks
-      skip "Skipping nic_groups tests because a nic_group is not defined" if nic_groups.empty?
+
+      @deployment = with_deployment
+      expect(bosh("-d #{@deployment.name} deploy #{@deployment.to_path}")).to succeed
     end
+
+    after(:all) do
+      @requirements.cleanup(@deployment)
+    end
+
     it 'assigns networks with the same nic_group to the same interface', ssh: true do
       job_networks = @spec['properties']['job_networks']
       networks_with_nic_groups = job_networks.select { |n| n['static_ip'] && n['nic_group'] }
 
-      deployment = with_deployment
-      expect(bosh("-d #{deployment.name} deploy #{deployment.to_path}")).to succeed
-
-      cli_cmd = 'ip -j addr'
-      output = bosh_ssh('batlight', 0, cli_cmd, deployment: deployment.name, result: true, column: 'stdout').output
+      output = bosh_ssh('batlight', 0, 'ip -j addr', deployment: @deployment.name, result: true,
+                                                     column: 'stdout').output
       raw_interfaces_json = JSON.parse(output)
 
       ip_to_interface_map = {}
@@ -71,7 +82,7 @@ describe 'network configuration' do
         interface_name = ip_to_interface_map[static_ip]
 
         expect(interface_name).not_to be_nil,
-                                 "Static IP #{static_ip} from network '#{network['name']}' not found on any interface"
+                                      "Static IP #{static_ip} from network '#{network['name']}' not found on any interface"
         nic_group_to_interface_set[nic_group] << interface_name
       end
 

--- a/templates/deployment.yml.erb
+++ b/templates/deployment.yml.erb
@@ -54,10 +54,13 @@ instance_groups:
         <% if i == 0 %>
         default: [dns, gateway]
         <% end %>
-      <% if properties.use_static_ip && network.static_ip %>
+        <% if properties.use_static_ip && network.static_ip %>
         static_ips:
-        - <%= network.static_ip %>
-      <% end %>
+          - <%= network.static_ip %>
+        <% end %>
+        <% if network.nic_group %>
+        nic_group: <%= network.nic_group %>
+        <% end %>
     <% end %>
     <% if properties.use_vip && properties.vip %>
       - name: static

--- a/templates/deployment.yml.erb
+++ b/templates/deployment.yml.erb
@@ -58,7 +58,7 @@ instance_groups:
         static_ips:
           - <%= network.static_ip %>
         <% end %>
-        <% if network.nic_group %>
+        <% if properties.use_nic_groups && network.nic_group %>
         nic_group: <%= network.nic_group %>
         <% end %>
     <% end %>


### PR DESCRIPTION
Adding tests to verify the `nic_group` property functionality in network configuration. The property allows to control which network interfaces are assigned to which networks on a VM, which is required for dual-stack IPv4/IPv6 deployments and multi-NIC scenarios. By default, BOSH usually creates a new NIC for each network on the hyperscaler.

```yaml
networks:
- name: ipv4-network
  nic_group: 1
  default:
    - dns
    - gateway
- name: ipv6-network
  nic_group: 1
```
