### PR TITLE
ruby 3.4 compatibility

### DIFF
--- a/lib/bat/bosh_runner.rb
+++ b/lib/bat/bosh_runner.rb
@@ -1,6 +1,5 @@
 require 'common/exec'
 require 'json'
-require 'base64'
 require 'bat/stemcell'
 require 'bat/release'
 require 'bat/deployment'


### PR DESCRIPTION
Remove "require base64" since we aren't using it and it isn't included by default in Ruby 3.4.