### PR TITLE
Make OpenStack volume type configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ properties:
   instances: 1
   instance_type: some-ephemeral
   flavor_with_no_ephemeral_disk: no-ephemeral
+  volume_type: premium # (optional) Volume type for persistent disks, defaults to 'gp2' if not specified
   vip: 0.0.0.43 # Virtual (public/floating) IP assigned to the bat-release job vm ('static' network), for ssh testing
   second_static_ip: 10.253.3.29 # Secondary (private) IP to use for reconfiguring networks, must be in the primary network & different from static_ip
   networks:

--- a/templates/cloud_config_openstack.yml.erb
+++ b/templates/cloud_config_openstack.yml.erb
@@ -54,6 +54,6 @@ disk_types:
 - name: <%= disk_type.name %>
   disk_size: <%= disk_type.disk_size %>
   cloud_properties:
-    type: gp2
+    type: <%= properties.volume_type || 'gp2' %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The volume type for disk_types was hardcoded to 'gp2', which is an AWS-specific volume type. Different OpenStack environments have different volume type names (e.g., 'standard_hdd', 'premium', etc.).

This change makes the volume type configurable via the 'volume_type' property in bat.yml while maintaining backward compatibility by defaulting to 'gp2' if not specified.

Example usage in bat.yml:
  properties:
    volume_type: premium