### PR TITLE
CI: cleanup `run-bats` task

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,17 @@
+name: Run BATs Specs
+on: [push, pull_request]
+
+jobs:
+  bats_specs:
+    strategy:
+      matrix:
+        ruby: ['3.3', '3.4', '4.0', head]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rspec spec/bat
+        continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == '4.0' }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,4 +14,3 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
       - run: bundle install
       - run: bundle exec rspec spec/bat
-        continue-on-error: ${{ matrix.ruby == 'head' || matrix.ruby == '4.0' }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,16 @@
-# encoding: UTF-8
 source 'https://rubygems.org'
 
 gem 'bosh_common'
 gem 'bosh-template'
+
+gem 'bcrypt_pbkdf'
 gem 'httpclient'
+gem 'ed25519'
+
+gem 'minitar'
 gem 'net-ssh'
 gem 'net-ssh-gateway'
-gem 'minitar'
+
 gem 'rspec'
-gem 'ed25519'
-gem 'bcrypt_pbkdf'
+gem 'logger' # Ruby 4.x
+gem 'ostruct' # Ruby 4.x - used by `bosh-template`

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-set -e
-
-export BAT_STEMCELL=$(realpath stemcell/*.tgz)
-export BAT_DEPLOYMENT_SPEC=$(realpath bats-config/bats-config.yml)
-export BAT_BOSH_CLI=$(realpath "$(which bosh)")
+BAT_STEMCELL=$(realpath stemcell/*.tgz)
+BAT_DEPLOYMENT_SPEC=$(realpath bats-config/bats-config.yml)
+BAT_BOSH_CLI=$(realpath "$(command -v bosh)")
+export BAT_STEMCELL
+export BAT_DEPLOYMENT_SPEC
+export BAT_BOSH_CLI
 
 source bats-config/bats.env
 
-pushd $(realpath bats)
+pushd "$(realpath bats)"
   bundle install
-  bundle exec rspec spec $BAT_RSPEC_FLAGS
+
+  if declare -p BAT_RSPEC_FLAGS 2>/dev/null | grep -q 'declare \-a'; then
+    bundle exec rspec spec "${BAT_RSPEC_FLAGS[@]}"
+  else
+    # shellcheck disable=SC2086
+    bundle exec rspec spec ${BAT_RSPEC_FLAGS:-}
+  fi
 popd

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -1,11 +1,6 @@
 ---
 platform: linux
 
-image_resource:
-  type: registry-image
-  source:
-    repository: bosh/integration
-
 inputs:
   - name: bats
   - name: bats-config

--- a/spec/bat/bosh_helper_spec.rb
+++ b/spec/bat/bosh_helper_spec.rb
@@ -12,6 +12,7 @@ describe Bat::BoshHelper do
     bosh_helper.instance_variable_set('@bosh_runner', bosh_runner)
     stub_const('ENV', {})
     bosh_helper.instance_variable_set('@logger', Logger.new('/dev/null'))
+    allow(bosh_helper).to receive(:puts) # silence output in specs
   end
 
   describe '#ssh_options' do
@@ -382,8 +383,8 @@ OUTPUT
         allow(bosh_runner).to receive(:bosh).with('instances --details').and_return(fake_result)
       end
 
-      it 'returns nil' do
-        expect{bosh_helper.wait_for_process_state('jessez', '0', 'running', 0)}.to raise_error
+      it 'raises an error' do
+        expect{bosh_helper.wait_for_process_state('jessez', '0', 'running', 0)}.to raise_error("Instance is still not in expected process state: running")
       end
     end
 
@@ -393,8 +394,8 @@ OUTPUT
         allow(bosh_runner).to receive(:bosh).with('instances --details').and_return(fake_result)
       end
 
-      it 'returns nil' do
-        expect{bosh_helper.wait_for_process_state('jessez', '0', 'running', 0)}.to raise_error
+      it 'raises an error' do
+        expect{bosh_helper.wait_for_process_state('jessez', '0', 'running', 0)}.to raise_error("Instance is still not in expected process state: running")
       end
     end
 


### PR DESCRIPTION
- remove `image_resource`
  - this pointed at an outdated location; should be provided by the invoker
- shellcheck fixes
- add action to run bats own specs